### PR TITLE
[Inclusive-Language] change comment with "sanity" to "soundness" 

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -718,7 +718,7 @@ internal func _isUnique<T>(_ object: inout T) -> Bool {
 }
 
 /// Returns `true` if `object` is uniquely referenced.
-/// This provides sanity checks on top of the Builtin.
+/// This provides soundness checks on top of the Builtin.
 @_transparent
 public // @testable
 func _isUnique_native<T>(_ object: inout T) -> Bool {


### PR DESCRIPTION
## Background 

Since 2020, Apple has been promoting inclusive language in its source code. For example, Apple's Contributor Code of Conduct v1.4 recommends opting for "soundness check" over the non-ableist term "sanity check." 

Source: https://www.swift.org/code-of-conduct/ 

## Changes 
I replaced a term in a comment called "sanity check" to "soundness check." 

## Test Plan
Because I only changed a comment, no test plan is necessary. 